### PR TITLE
Make the Expedition background consistent (Vinktastic Edition)

### DIFF
--- a/src/Hooks/Expedition.cs
+++ b/src/Hooks/Expedition.cs
@@ -1,17 +1,20 @@
 ﻿using On.Expedition;
+using MoreSlugcats;
 
 namespace Vinki;
 public static partial class Hooks
 {
-	public static void ApplyExpeditionHooks()
-	{
+    public static void ApplyExpeditionHooks()
+    {
         NeuronDeliveryChallenge.ValidForThisSlugcat += NeuronDeliveryChallenge_ValidForThisSlugcat;
         PearlDeliveryChallenge.Update += PearlDeliveryChallenge_Update;
+	On.Menu.ExpeditionMenu.SwitchBackground += ExpeditionMenu_SwitchBackground;
     }
     public static void RemoveExpeditionHooks()
     {
         NeuronDeliveryChallenge.ValidForThisSlugcat -= NeuronDeliveryChallenge_ValidForThisSlugcat;
         PearlDeliveryChallenge.Update -= PearlDeliveryChallenge_Update;
+	On.Menu.ExpeditionMenu.SwitchBackground -= ExpeditionMenu_SwitchBackground;
     }
 
     private static bool NeuronDeliveryChallenge_ValidForThisSlugcat(NeuronDeliveryChallenge.orig_ValidForThisSlugcat orig, Expedition.NeuronDeliveryChallenge self, SlugcatStats.Name slugcat)
@@ -40,5 +43,14 @@ public static partial class Hooks
                 }
             }
         }
+    }
+
+    private void ExpeditionMenu_SwitchBackground(On.Menu.ExpeditionMenu.orig_SwitchBackground orig, ExpeditionMenu self)
+    {
+    	if (self.characterSelect.slugcatName.text == "THE VINKI")
+    	{
+            self.characterSelect.slugcatScene = MoreSlugcatsEnums.MenuSceneID.Landscape_VS;
+    	}
+    	orig(self);
     }
 }


### PR DESCRIPTION
Same as the last pull request, but working this time!

The only thing this does is that it makes the background when selecting Vinki in the Expedition menu automatically become the Pipeyard background rather than a random one.